### PR TITLE
chore: update toolchain to OTP 28 + verify latest deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.1.2"
+          otp-version: "28"
           gleam-version: "1.17.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           buildInputs = with pkgs; [
             gleam
             rebar3
-            erlang_27
+            erlang_28
             nodejs
           ];
 

--- a/src/json/blueprint/schema.gleam
+++ b/src/json/blueprint/schema.gleam
@@ -2,7 +2,7 @@ import gleam/bit_array
 import gleam/crypto
 import gleam/json
 import gleam/list
-import gleam/option.{type Option, None, Some}
+import gleam/option.{type Option, None}
 
 pub const json_schema_version = "http://json-schema.org/draft-07/schema#"
 


### PR DESCRIPTION
Refreshes the dev environment and dependencies to the latest.

## Toolchain
| | Before | After |
|---|---|---|
| Gleam | 1.17.0 | 1.17.0 (already latest in nixpkgs) |
| Erlang/OTP | OTP 27 (ERTS 15.2.7) | **OTP 28** (28.5.0.1, ERTS 16.4.0.1) |
| Node | v24.15.0 | v24.15.0 |

`flake.lock` was already at the newest `nixos-unstable` (2026-06-10), so `nix flake update` was a no-op. `flake.nix` bumps the pinned `erlang_27` → `erlang_28`.

## Dependencies
Already resolving to the latest published versions — no constraint changes needed:
`gleam_stdlib` 1.0.3, `gleam_json` 3.1.0, `gleam_crypto` 1.6.0, `gleeunit` 1.11.0.

## Code
- `src/json/blueprint/schema.gleam`: drop the unused `Some` constructor import (only the fully-qualified `option.Some` is used) — makes the build warning-free under Gleam 1.17.

## CI
- `.github/workflows/test.yml`: `otp-version` `27.1.2` → `28`.

## Verification
`gleam build` (no warnings), `gleam format --check src test`, `gleam test --target=erlang`, `gleam test --target=javascript` — **21 tests pass on both targets**; `nix flake check` passes. All run on OTP 28.