### PR TITLE
chore: update toolchain and dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Maintenance refresh of the dev toolchain and dependencies. The bulk of the
modernization work was already completed in the recent commits (`chore: update
toolchain to OTP 28` and `chore: release 1.7.0`), so this PR confirms everything
is current and refreshes the Nix lock.

## Toolchain

- **Gleam: 1.17.0 → 1.17.0** (already latest stable — no bump needed)
- **Erlang/OTP: 28 → 28** (already latest)
- `nix flake update` refreshed the `nixpkgs` input (2026-06-10 → 2026-06-16),
  which continues to pin Gleam 1.17.0 / OTP 28.
- CI (`.github/workflows/test.yml`) already pins `otp-version: "28"` and
  `gleam-version: "1.17.0"` — no change required.

## Dependencies

`gleam update` produced **no manifest changes** — all deps are already at their
latest stable releases:

| Package | Version | Notes |
|---|---|---|
| gleam_stdlib | 1.0.3 | latest |
| gleam_json | 3.1.0 | latest (no 4.x exists — no holdback) |
| gleam_crypto | 1.6.0 | latest |
| gleeunit (dev) | 1.11.0 | latest |

No holdbacks or breaking-major deferrals were necessary.

## Verification (all run inside the Nix flake)

- `gleam build --warnings-as-errors` — clean, **zero warnings**
- `gleam format --check src test` — passes
- `gleam test --target=erlang` — **21 passed, no failures**
- `gleam test --target=javascript` — **21 passed, no failures**

## Version

Library version left at **1.7.0**. This PR contains no library source or
dependency changes (only a `flake.lock` refresh), so no release bump is
warranted; the `1.7.0` release commit already covers the current dep/toolchain
state.

## Known limitations / blockers

None.